### PR TITLE
fix: per-cloud base speed with event-driven multipliers

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,25 @@
+# CloudBot
+
+A Twitch chatbot and stream overlay with interactive visual effects, session management, show notes, and community engagement features.
+
+## Language
+
+**Cloud** (floating): The animated cloud images (`cloud-*.png`) that scroll across the top of the overlay screen. Each has its own random base speed set at creation.
+_Avoid_: Cloud GIF, reaction image
+
+**Cloud reaction**: The `cloud()` function that displays a CB-*.gif reaction image in the overlay viewer for 5 seconds.
+_Avoid_: Floating cloud, moving cloud
+
+**Cloud speed**: The CSS `animation-duration` of a floating cloud. Composed of a per-cloud random base duration and a global speed multiplier.
+
+**Base speed**: Each floating cloud's individual random animation duration (50–200s), assigned once at creation and stored in `dataset.baseDuration`.
+
+**Speed multiplier**: A factor applied to all floating clouds' base speeds in response to chat activity or Twitch events. Multipliers replace the old fixed per-condition durations so clouds retain their individual differences while collectively speeding up or slowing down.
+
+**Message velocity**: Chat messages per minute (MPM) tracked over a rolling 60-second window. Used by `applyDynamicWeather` to modulate cloud speed and sky appearance.
+
+**Dynamic weather**: Automatic weather system that changes the sky color and optionally triggers rain based on message velocity tiers.
+
+**Weather override**: A forced weather state (thunderstorm or rainbow sunshine) triggered by Twitch events (raid, sub, cheer) that temporarily supersedes dynamic weather tracking. Decays after a timeout and returns to message-velocity-based weather.
+
+**Speed factors**: Canonical multiplier values. Normal = 1.0, light activity (10–25 MPM) = 0.5, high activity (≥25 MPM) = 0.12, thunderstorm (raid) = 0.08, sunshine (sub/cheer) = 1.8.

--- a/src/public/cloudbot.js
+++ b/src/public/cloudbot.js
@@ -1133,6 +1133,7 @@ CreateCloud = function () {
     const elem = document.createElement('div');
     elem.style.cssText = elemStyle;
     elem.className = "movingCloud";
+    elem.dataset.baseDuration = animDuration;
     const cloud = document.createElement('img');
     cloud.src = `public/medias/cloud-${cloudImage}.png`;
     let sky = document.getElementById("sky");

--- a/src/public/index.html
+++ b/src/public/index.html
@@ -782,25 +782,34 @@
             }
         }, 10000);
 
+        function setCloudSpeedMultiplier(factor) {
+            document.querySelectorAll('.movingCloud').forEach(cloud => {
+                const base = parseFloat(cloud.dataset.baseDuration);
+                if (base) {
+                    cloud.style.animationDuration = `${base * factor}s`;
+                }
+            });
+        }
+
         function applyDynamicWeather(mpm) {
             const sky = document.getElementById("sky");
             if (!sky) return;
 
             let targetClass = "lightcloud";
-            let animDuration = 100;
+            let factor = 1.0;
             let shouldRain = false;
 
             if (mpm < 10) {
                 targetClass = "lightcloud";
-                animDuration = 100;
+                factor = 1.0;
                 shouldRain = false;
             } else if (mpm >= 10 && mpm < 25) {
                 targetClass = "darkcloud";
-                animDuration = 50;
+                factor = 0.5;
                 shouldRain = false;
             } else if (mpm >= 25) {
                 targetClass = "darkcloud";
-                animDuration = 12;
+                factor = 0.12;
                 shouldRain = true;
             }
 
@@ -816,9 +825,7 @@
                 stopSound("rain", SoundEnum.rain, true);
             }
 
-            document.querySelectorAll('.movingCloud').forEach(cloud => {
-                cloud.style.animationDuration = `${animDuration}s`;
-            });
+            setCloudSpeedMultiplier(factor);
         }
 
         function cleanWeatherOverride() {
@@ -831,9 +838,7 @@
             if (sky) {
                 sky.className = "lightcloud";
             }
-            document.querySelectorAll('.movingCloud').forEach(cloud => {
-                cloud.style.animationDuration = '100s';
-            });
+            setCloudSpeedMultiplier(1.0);
             const rb = document.getElementById("rainbowOverlay");
             if (rb) rb.remove();
             const sn = document.getElementById("sunOverlay");
@@ -948,9 +953,7 @@
             makeItRain();
             playSound("rain", SoundEnum.rain, true);
 
-            document.querySelectorAll('.movingCloud').forEach(cloud => {
-                cloud.style.animationDuration = '8s';
-            });
+            setCloudSpeedMultiplier(0.08);
 
             weatherOverrideTimeout = setTimeout(() => {
                 cleanWeatherOverride();
@@ -973,9 +976,7 @@
             document.querySelectorAll('.rain').forEach(el => el.innerHTML = '');
             stopSound("rain", SoundEnum.rain, true);
 
-            document.querySelectorAll('.movingCloud').forEach(cloud => {
-                cloud.style.animationDuration = '180s';
-            });
+            setCloudSpeedMultiplier(1.8);
 
             playSound("celebrationSound", SoundEnum.yeah);
 


### PR DESCRIPTION
## Summary

Issue #110 — clouds all moved at the same speed because weather logic set a fixed `animationDuration` on all clouds.

## Changes

- Each cloud now stores its random base duration (50–200s) in `dataset.baseDuration` at creation
- Added `setCloudSpeedMultiplier(factor)` helper that reads each cloud's base duration and computes `base × factor`
- Replaced all 4 hardcoded cloud-speed overrides with multiplier calls:
  | Condition | Factor |
  |---|---|
  | Normal | 1.0× |
  | Light activity (10–25 MPM) | 0.5× |
  | High activity (≥25 MPM) | 0.12× |
  | Thunderstorm (raid) | 0.08× |
  | Sunshine (sub/cheer) | 1.8× |
- Added `CONTEXT.md` with canonical terminology

Clouds retain their individual speed differences while collectively scaling.